### PR TITLE
Add reload function.

### DIFF
--- a/Assets/ImportAssets/TestLevel/testscene.unity
+++ b/Assets/ImportAssets/TestLevel/testscene.unity
@@ -28602,9 +28602,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fire: {fileID: 8300000, guid: 8602b7d5cd15c1943a50aa53f171c8cf, type: 3}
-  particlePrefab: {fileID: 1562480864431258, guid: db0c6844488af4c2bafd8b1984f32fcc,
-    type: 2}
-  muzzleEffectPrefab: {fileID: 1869226186287310, guid: ff3a2bd1b26604da4862207d003dbe35,
+  reload: {fileID: 8300000, guid: 3c5c1d4d7b9307c458890a4beb12e4ae, type: 3}
+  EffectPrefab: {fileID: 1869226186287310, guid: ff3a2bd1b26604da4862207d003dbe35,
     type: 2}
 --- !u!1 &1825825693
 GameObject:

--- a/Assets/Standard Assets/Characters/FirstPersonCharacter/Scripts/BulletController.cs
+++ b/Assets/Standard Assets/Characters/FirstPersonCharacter/Scripts/BulletController.cs
@@ -74,8 +74,8 @@ public class BulletController : MonoBehaviour {
 		if(Input.GetKeyDown("r") && bulletBoxNum > 0 && bulletNum < maxBulletNum){
 			onReloading = true;        //リロード時に少しの間撃てなくなる
 			gunAudioSource.PlayOneShot (reload, 1.0f);
-			bulletBoxNum--;            //装弾数を上限値まで増やす。
-			bulletNum = maxBulletNum;  //弾倉数を減らす。
+			bulletBoxNum--;            //弾倉数を減らす。
+			bulletNum = maxBulletNum;  //装弾数を上限値まで増やす。
 			Invoke ("FinishReloading", 2.1f);//リロード音がなっている間は撃てないようにしたいから2.1
 		}
 	}

--- a/Assets/Standard Assets/Characters/FirstPersonCharacter/Scripts/BulletController.cs
+++ b/Assets/Standard Assets/Characters/FirstPersonCharacter/Scripts/BulletController.cs
@@ -4,8 +4,8 @@ using UnityEngine;
 
 public class BulletController : MonoBehaviour {
 
-	private int bulletNum;  //弾数
-	private int bulletBoxNum;  //弾倉数
+	public int bulletNum;  //弾数
+	public int bulletBoxNum;  //弾倉数
 	private int maxBulletNum;  //装弾上限数
 	private float coolTime;  //クールタイム
 	private float effectLifeTime; //パーティクルの継続時間
@@ -40,14 +40,14 @@ public class BulletController : MonoBehaviour {
 		if(Input.GetMouseButtonDown(0) && canShot == true && bulletNum > 0 && onReloading == false){
 
 			gunAudioSource.PlayOneShot (fire, 1.0f);  //発砲音再生
-			muzzleEffect = (GameObject)Instantiate(EffectPrefab);
-			muzzleEffect.transform.parent = transform;
+			muzzleEffect = (GameObject)Instantiate(EffectPrefab);  //銃口にエフェクト
+			muzzleEffect.transform.parent = transform;  
 			muzzleEffect.transform.localPosition = muzzleEffectPosition;
-			muzzleEffect.transform.rotation = transform.rotation;
+			muzzleEffect.transform.rotation = transform.rotation;//エフェクトの見え方がプレイヤーの向きに依存しないようにする
 			bulletNum --;  //撃てば弾が減る
 
 			Ray gunRay = Camera.main.ViewportPointToRay (new Vector3 (0.5f, 0.5f, 0.0f));  //画面中央からRayを飛ばす
-			Invoke("DestroyMuzzleEffect", effectLifeTime);
+			Invoke("DestroyMuzzleEffect", effectLifeTime);//銃口のエフェクトは少し経ったら消える
 
 			//クールタイム
 			canShot = false;
@@ -74,8 +74,10 @@ public class BulletController : MonoBehaviour {
 		if(Input.GetKeyDown("r") && bulletBoxNum > 0 && bulletNum < maxBulletNum){
 			onReloading = true;        //リロード時に少しの間撃てなくなる
 			gunAudioSource.PlayOneShot (reload, 1.0f);
-			bulletBoxNum--;            //弾倉数を減らす。
-			bulletNum = maxBulletNum;  //装弾数を上限値まで増やす。
+			while(bulletNum < maxBulletNum && bulletBoxNum > 0){
+				bulletNum++;
+				bulletBoxNum--;
+			}
 			Invoke ("FinishReloading", 2.1f);//リロード音がなっている間は撃てないようにしたいから2.1
 		}
 	}


### PR DESCRIPTION
# WHAT
・弾薬数の設定
・弾薬上限数の設定
・弾倉の設定
・リロード機能
・リロード音の設定

# WHY
機能制限をしてゲーム性を高めるため。
音声演出をしてリアリティを出すため。

# STEP
・弾薬数の設定
>int型の bulletNum変数を定義し、発砲時(クリック時)にデクリメントし弾薬の消費を実装した。

・弾薬上限数の設定
>int型maxBulletNum変数を定義し、30で初期化。

・弾倉の設定
>int型のbulletBoxNum変数を定義し、150で初期化。

・リロード機能
>"r"キーを押した時に、
>1.弾薬数が弾薬上限数を下回っている
>2.弾倉数が残っている(bulletBoxNumが0より大きい)
>の条件を満たしている場合リロード
>bulletBoxNumをデクリメントし、弾倉の消費を実装
>bulletNumにmaxBulletNumを代入し弾薬の装填を実装

・リロード音の設定
>AudioClip型のreload変数にリロード音をInspectorビューから格納
>リロード時に再生し、bool型のonReloading変数を用いてリロード音がなっている間は発砲ができないようにした

# CheckList
・ステージの実装
・Playerの実装
・しゃがみ機能の実装
・発砲機能の実装
・リロード機能の実装

# VIEW
[リロードGIF](https://gyazo.com/46fb2ffdd72200750ec832d95814249c)