### PR TITLE
Add UI function.

### DIFF
--- a/Assets/SelfMadeAssets/SelfMadeScripts/BulletController.cs
+++ b/Assets/SelfMadeAssets/SelfMadeScripts/BulletController.cs
@@ -77,7 +77,6 @@ public class BulletController : MonoBehaviour {
 				landingEffect = (GameObject)Instantiate(EffectPrefab, landingEffectPosition , transform.rotation);
 				landingEffect.transform.rotation = transform.rotation;
 
-				print (hit.collider.gameObject);
 				//-------スコアに関する処理-------------
 				scoreController = hit.collider.transform.parent.GetComponent<ScoreController> ();
 				if(scoreController != null){

--- a/Assets/SelfMadeAssets/SelfMadeScripts/UIController.cs
+++ b/Assets/SelfMadeAssets/SelfMadeScripts/UIController.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class UIController : MonoBehaviour {
+
+	public ScoreController scoreController;  //UIに表示させる数値の参照元
+	public BulletController bulletController;  //UIに表示させる数値の参照元
+
+	public Text scoreText;
+	public Text timerText;
+	public Text bulletNumText;
+	public Text bulletBoxNumText;
+
+	public int scoreNum;
+	private float timer;
+	public int bulletNum;
+	public int bulletBoxNum;
+
+	// Use this for initialization
+	void Start () {
+		timer = 90;
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		timer -= Time.deltaTime;
+
+		if(timer <= 0){//タイマーが0秒になったらどうなるのかが分からないので一旦0sの表記のまま何も変化ない状態にする
+			timer = 0.0f;
+		}
+
+		scoreNum = scoreController.score;
+		bulletNum = bulletController.bulletNum;
+		bulletBoxNum = bulletController.bulletBoxNum;
+
+		scoreText.text = "Pt:" + scoreNum;
+		timerText.text = "Time:" + timer.ToString("0.0") + "s";
+		bulletNumText.text = "Bullet:" + bulletNum;
+		bulletBoxNumText.text = "BulletBox:" + bulletBoxNum;
+	
+	}
+}

--- a/Assets/SelfMadeAssets/SelfMadeScripts/UIController.cs.meta
+++ b/Assets/SelfMadeAssets/SelfMadeScripts/UIController.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: fc4fc2163d0f143e5b143a367ba20b29
+timeCreated: 1492200160
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# WHAT
・レティクルの作成
・タイマーの作成
・弾薬数の表示

# WHY
レティクルなしの状態だと着弾点がどこか予測しづらく思うように射撃ができないから。
現状タイマーは90sから0sへ減って行くだけの仕様ではあるが、タイムアタックなどのルールがない状態だと目的のないゲームになってしまい飽きてしまうから。
弾薬数の表示をすることでリロードのタイミングを考えるようになったり、プレイの助けになるから。また残弾数が表示されない状態で残弾数が0になった時に弾が撃てずストレスになるから。

#STEP
・レティクルの作成
>真っ白な正方形のテクスチャ？を線状に引き伸ばした物を4つ組み合わせてレティクルを実装した。

・タイマーの作成
>float型のtimer変数を定義し90で初期化、それを毎フレームTime.deltaTime分減算していきその計算結果がテキストで表示される。

・弾薬数の表示
>毎フレームBulletController.csのbulletNum、bulletBoxNumの値をUIController.csのbulletNum、bulletBoxNumに代入し更新し続けて、それを表示した。

#VIEW
[GIF](https://gyazo.com/878cfec26dcc8d982162e4f701e3efd9)